### PR TITLE
Potential fix for code scanning alert no. 7: Client-side cross-site scripting

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,8 @@
     "react-dom": "^19.2.0",
     "react-icons": "^5.5.0",
     "swr": "^2.3.6",
-    "zod": "^4.1.12"
+    "zod": "^4.1.12",
+    "sanitize-html": "^2.17.0"
   },
   "devDependencies": {
     "@eslint/config-array": "^0.21.1",

--- a/src/lib/mail.ts
+++ b/src/lib/mail.ts
@@ -1,7 +1,7 @@
 'use server';
 
 import nodemailer from 'nodemailer';
-
+import sanitizeHtml from 'sanitize-html';
 /**
  * Sends an email using the appropriate SMTP server configuration based on the environment.
  *
@@ -35,10 +35,13 @@ export async function sendEmail(to: string, subject: string, html: string) {
         });
     }
 
+    // Sanitize HTML before sending email
+    const sanitizedHtml = sanitizeHtml(html);
+
     await transporter.sendMail({
         from: '"Toastboy FC Mailer" <footy@toastboy.co.uk>',
         to: to,
         subject: subject,
-        html: html,
+        html: sanitizedHtml,
     });
 }


### PR DESCRIPTION
Potential fix for [https://github.com/toastboy/next-www-toastboy/security/code-scanning/7](https://github.com/toastboy/next-www-toastboy/security/code-scanning/7)

The best way to fix this vulnerability is to sanitize the `html` string before including it in the email body. This ensures that any malicious scripts or unwanted HTML elements are stripped or neutralized, protecting email recipients from phishing and similar attacks. The fix should be applied inside the `sendEmail` function, immediately before passing `html` to `transporter.sendMail`. We can use a well-known package such as `sanitize-html` for robust HTML sanitization. 

To implement the fix in `src/lib/mail.ts`:
- Add an import for `sanitize-html`.
- Sanitize the `html` parameter before usage.
- Pass the sanitized HTML to the transporter.

Only modify the code as shown; do not change existing logic or parameter conventions.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
